### PR TITLE
Ensure seed script clears tables before seeding

### DIFF
--- a/seed_test_data.py
+++ b/seed_test_data.py
@@ -1,0 +1,27 @@
+from app import SessionLocal, Company, Record
+
+
+def seed():
+    db = SessionLocal()
+    try:
+        db.query(Record).delete()
+        db.query(Company).delete()
+        db.commit()
+
+        company = Company(name="Test Company")
+        db.add(company)
+        db.commit()
+
+        records = [
+            Record(name="First Record", company_id=company.id),
+            Record(name="Second Record", company_id=company.id),
+        ]
+        db.add_all(records)
+        db.commit()
+        print("Seeded demo data.")
+    finally:
+        db.close()
+
+
+if __name__ == "__main__":
+    seed()


### PR DESCRIPTION
## Summary
- add seed_test_data.py to reset Record and Company tables before inserting sample data

## Testing
- `env PYTHONDONTWRITEBYTECODE=1 python seed_test_data.py`


------
https://chatgpt.com/codex/tasks/task_e_6899cf08d9b08330acf55fcec2671dc0